### PR TITLE
🐛 Fix: Auth logout

### DIFF
--- a/frontend/src/components/UserInfo/UserInfoForm.tsx
+++ b/frontend/src/components/UserInfo/UserInfoForm.tsx
@@ -45,6 +45,7 @@ const UserInfoForm = ({ handleEditingMode }) => {
           <input
             id="nickname"
             type="text"
+            required
             maxLength={6}
             value={tempNickname}
             placeholder="닉네임(최대 6자리까지)"
@@ -56,6 +57,7 @@ const UserInfoForm = ({ handleEditingMode }) => {
           <input
             id="phone"
             type="tel"
+            required
             maxLength={11}
             value={tempPhone}
             placeholder={'11자리 숫자를 입력하세요'}

--- a/frontend/src/containers/Header/Header.tsx
+++ b/frontend/src/containers/Header/Header.tsx
@@ -22,9 +22,11 @@ const Header = () => {
 
   netlifyIdentity.on('login', async ({ id, email, user_metadata: { full_name: nickname } }) => {
     let authorizedUser = {};
-
-    const { auth } = JSON.parse(sessionStorage.getItem('persist:root'));
-    const storedUser = JSON.parse(auth);
+    let storedUser = { id: null, nickname: null, email: null, phone: null, reservation: null, myReviews: null };
+    if (sessionStorage.getItem('persist:root')) {
+      const { auth } = JSON.parse(sessionStorage.getItem('persist:root'));
+      storedUser = JSON.parse(auth);
+    }
 
     const user = await createUser({ id, email, nickname });
 


### PR DESCRIPTION
logout 
- 로그아웃을 하지 않고 브라우저를 종료하거나 사이트에 재접속할 경우, 로그인된 상태임에도 헤더가 제대로 표시되지 않는 문제 해결
- session 체크 과정에서 null 여부를 먼저 확인한 뒤 파싱을 했어야 했는데 그 과정에서 오류가 있었습니다 
