### PR TITLE
호텔 이미지 모달 스타일 수정 및 이미지 넘버링 추가

### DIFF
--- a/frontend/src/components/Carousels/Button/ButtonVer2.style.ts
+++ b/frontend/src/components/Carousels/Button/ButtonVer2.style.ts
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+const ArrowButton = styled.button`
+  position: absolute;
+  top: 50%;
+  right: ${props => props.role === 'next' && '-40px'};
+  left: ${props => props.role === 'prev' && '-60px'};
+  transform: translateY(-50%);
+  width: 40px;
+  background-color: transparent;
+  cursor: pointer;
+  z-index: 10;
+`;
+
+export { ArrowButton };

--- a/frontend/src/components/Carousels/Button/ButtonVer2.tsx
+++ b/frontend/src/components/Carousels/Button/ButtonVer2.tsx
@@ -1,0 +1,17 @@
+import { ArrowButton } from './ButtonVer2.style';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faAnglesRight, faAnglesLeft } from '@fortawesome/free-solid-svg-icons';
+
+const ButtonVer2 = ({ role, onClick }) => {
+  return (
+    <ArrowButton role={role} onClick={onClick}>
+      {role === 'prev' ? (
+        <FontAwesomeIcon icon={faAnglesLeft} style={{ color: '#FFF' }} size="4x" />
+      ) : (
+        <FontAwesomeIcon icon={faAnglesRight} style={{ color: '#FFF' }} size="4x" />
+      )}
+    </ArrowButton>
+  );
+};
+
+export default ButtonVer2;

--- a/frontend/src/components/HotelImage/HotelImage.style.ts
+++ b/frontend/src/components/HotelImage/HotelImage.style.ts
@@ -51,7 +51,7 @@ export const ImageModal = styled.div`
   left: 0px;
   width: 100vw;
   height: 100vh;
-  background-color: #141d38;
+  background-color: #1a1a1a;
   color: #ffffff;
 `;
 

--- a/frontend/src/components/HotelImage/HotelImage.tsx
+++ b/frontend/src/components/HotelImage/HotelImage.tsx
@@ -13,7 +13,7 @@ import {
   ImageModalTitle,
 } from './HotelImage.style';
 import { ModalCloseBtn } from '../Map/map.style';
-import Button from '../Carousels/Button/Button';
+import ButtonVer2 from '../Carousels/Button/ButtonVer2';
 import Slider from 'react-slick';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
@@ -31,8 +31,8 @@ const HotelImage = ({ photos }) => {
       slidesToShow: 1,
       slidesToScroll: 1,
       initialSlide: initialslider,
-      nextArrow: <Button role="next" onClick={() => {}} />,
-      prevArrow: <Button role="prev" onClick={() => {}} />,
+      nextArrow: <ButtonVer2 role={'next'} onClick={() => {}} />,
+      prevArrow: <ButtonVer2 role={'prev'} onClick={() => {}} />,
     };
 
     return (
@@ -51,7 +51,8 @@ const HotelImage = ({ photos }) => {
             <Slider {...settings}>
               {photos.map((photo, index) => (
                 <div key={index.toString()}>
-                  <Image src={photo}></Image>
+                  <Image src={photo} alt={'호텔 기본 이미지' + index + 1}></Image>
+                  <div>{index + 1 + '/' + photos.length}</div>
                 </div>
               ))}
             </Slider>


### PR DESCRIPTION
#138 
-  저번 주 트러블슈팅 피드백 중 호텔 이미지 모달의 스타일을 변경사항을 바탕으로 개선
- 기존 캐러셀 슬라이드 버튼의 디자인을 화살표 형태의 크기를 좀 더 키워서 적용(새로운 button 컴포넌트를 추가)
- 모달의 배경색도 더 어두운 색상으로 변경했습니다
- 페이지 넘버링은 현재 슬라이드 인덱스로 넣어놓은 상태라 슬라이드가 움직일 때 마다 같이 움직이는 형태로 조금 이상한(?) 모양새여서 라이브러리 내에 기능이 있는지 조사중입니다. 찾아보고 좀 더 개선해서 수정하겠습니다. 