### PR TITLE
결제페이지 기능 구현 및 페이지 이동

### DIFF
--- a/backend/data/payment.json
+++ b/backend/data/payment.json
@@ -1,7 +1,9 @@
-{
-  "paymentId": 1,
-  "userId": 1,
-  "reservationId": 1,
-  "cost": 22000,
-  "paymentDate": "2022-03-01"
-}
+[
+  {
+    "id": 1,
+    "userId": 1,
+    "reservationId": 1,
+    "cost": 22000,
+    "paymentDate": "2022-03-01"
+  }
+]

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,6 +6,7 @@ const app = express();
 let users = require('./data/users.json');
 let reservations = require('./data/reservations.json');
 let hotels = require('./data/hotels.json');
+let payments = require('./data/payment.json');
 let reviews = require('./data/reviews.json');
 
 const { PORT } = process.env;
@@ -119,16 +120,40 @@ app.get('/reviews/title/:id', (req, res) => {
   res.send([total, rating]);
 });
 
-app.get('/reserved/:hotelId', (req, res) => {
-  const { hotelId } = req.params;
-  const { checkIn, checkOut } = req.query;
+app.post('/reservation/payment', (req, res) => {
+  const id = generateId(payments);
+  const { reservationId, payment, paymentDate } = req.body;
+  const data = { paymentId: id, reservationId: reservationId, paymentDate: paymentDate, ...payment };
+  payments = [...payments, data];
+  console.log('payment', data);
+  res.send(data);
+})
 
-  const reservedRoom = [];
-  reservations.forEach(reservation => {
-    if (reservation.hotelId === +hotelId && +reservation.checkInDate.split('-').join('') >= +checkIn.split('-').join('') && +reservation.checkOutDate.split('-').join('') <= +checkOut.split('-').join('')) reservedRoom.push(reservation.spec);
+app.post('/reservation/reservation', (req, res) => {
+  const id = generateId(reservations);
+  const data = { id: id, ...req.body };
+  reservations = [...reservations, data];
+  console.log('reservation', data);
+  res.send(data);
+})
+
+app.post('/reservation/hotel', (req, res) => {
+  const id = generateId(hotels);
+  const data = { id: id, ...req.body };
+  hotels = [...hotels, data];
+  console.log('hotel', data);
+  res.send(data);
+})
+
+app.patch('/reservation/user', (req, res) => {
+  users.map(user => {
+    if (user.id === req.body.userId) {
+      user.reservations = [...user.reservations, req.body.reservationId];
+      return user;
+    }
   })
-
-  res.send(reservedRoom);
+  console.log(users);
+  res.send(users);
 })
 
 app.listen(PORT, () => {

--- a/backend/server.js
+++ b/backend/server.js
@@ -120,6 +120,18 @@ app.get('/reviews/title/:id', (req, res) => {
   res.send([total, rating]);
 });
 
+app.get('/reserved/:hotelId', (req, res) => {
+  const { hotelId } = req.params;
+  const { checkIn, checkOut } = req.query;
+
+  const reservedRoom = [];
+  reservations.forEach(reservation => {
+    if (reservation.hotelId === +hotelId && +reservation.checkInDate.split('-').join('') >= +checkIn.split('-').join('') && +reservation.checkOutDate.split('-').join('') <= +checkOut.split('-').join('')) reservedRoom.push(reservation.spec);
+  })
+
+  res.send(reservedRoom);
+});
+
 app.post('/reservation/payment', (req, res) => {
   const id = generateId(payments);
   const { reservationId, payment, paymentDate } = req.body;

--- a/frontend/src/components/Payment/Agreement.tsx
+++ b/frontend/src/components/Payment/Agreement.tsx
@@ -1,0 +1,56 @@
+import { useRef } from "react";
+import { FormArticle } from "./Payment.style";
+
+const Agreement = ({ reservation, setReservation }) => {
+
+  const totalAgree = useRef();
+  const agrees = useRef([]);
+
+  const handleAgree = e => {
+    if (e.target.id === 'total') {
+      // 전체 동의하기에 따라 선택사항 체크박스 활성화
+      setReservation({
+        ...reservation,
+        isAgrees: e.target.checked ? [true, true, true] : [false, false, false]
+      })
+      agrees.current.forEach(agree => agree.checked = e.target.checked);
+    } else {
+      const agreeArr = agrees.current.map(agree => agree.checked);
+      // 선택사항이 모두 체크되었을 때, 전체 동의하기 활성화 (!(3-true의 개수)=> 하나라도 false일 경우 false)
+      totalAgree.current.checked = Boolean(!(3 - agreeArr.reduce((sum, acc) => sum += +acc, 0)));
+      setReservation({
+        ...reservation,
+        isAgrees: agreeArr
+      })
+    }
+  }
+
+  return (
+    <FormArticle>
+      <section>
+        <div>
+          <input type="checkbox" id="total" ref={totalAgree} onClick={handleAgree} />
+          <label htmlFor="total">전체 동의하기</label>
+        </div>
+        <div className="agreeSection">
+          <input type="checkbox" id="agree1" ref={agree => agrees.current[0] = agree} onClick={handleAgree} />
+          <label htmlFor="agree1"> [필수] 만 14세 이상 이용 동의</label>
+        </div>
+        <div className="agreeSection">
+          <input type="checkbox" id="agree2" ref={agree => agrees.current[1] = agree} onClick={handleAgree} />
+          <label htmlFor="agree2"> [선택] 이벤트, 혜택 정보 수신 동의</label>
+        </div>
+        <div className="agreeSection">
+          <input type="checkbox" id="agree3" ref={agree => agrees.current[2] = agree} onClick={handleAgree} />
+          <label htmlFor="agree3"> [선택] 이벤트, 혜택 정보 전송을 위한 개인정보 수집 및 이용 동의</label>
+        </div>
+      </section>
+      <p>
+        이용규칙, 취소 및 환불 규칙, 개인정보 수집 및 이용 및 개인정보 제3자 제공에 동의하실 경우 결제하기를
+        클릭해주세요.
+      </p>
+    </FormArticle>
+  )
+}
+
+export default Agreement;

--- a/frontend/src/components/Payment/Notice.tsx
+++ b/frontend/src/components/Payment/Notice.tsx
@@ -1,0 +1,25 @@
+import { SectionTitle, FormArticle } from './Payment.style';
+
+const Notice = () => {
+  return (
+    <FormArticle>
+      <SectionTitle className="srOnly">notice</SectionTitle>
+      <div className="notice">
+        <h5>
+          <i>ⓘ</i>현장결제
+        </h5>
+        <p>추가 인원 비용 등의 현장 결제 발생 상품을 확인하세요.</p>
+        <h5>
+          <i>ⓘ</i>취소 불가 및 수수료
+        </h5>
+        <p>추가 및 환불 규정에 따라 취소 불가, 수수료가 발생할 수 있습니다.</p>
+        <h5>
+          <i>ⓘ</i>미성년자 및 법정 대리인 필수
+        </h5>
+        <p>미성년자는 법정 대리인 동행 없이 투숙이 불가능합니다.</p>
+      </div>
+    </FormArticle>
+  )
+}
+
+export default Notice;

--- a/frontend/src/components/Payment/Payment.style.ts
+++ b/frontend/src/components/Payment/Payment.style.ts
@@ -1,0 +1,170 @@
+import styled from 'styled-components';
+
+export const ReservationWrapper = styled.div`
+  padding: 10px;
+
+  section {
+    margin-bottom: 30px;
+  }
+
+  input[type='checkbox'] {
+    display: none;
+  }
+
+  input[type='checkbox'] + label {
+    height: 30px;
+    display: inline-block;
+    cursor: pointer;
+    padding-left: 30px;
+    line-height: 24px;
+    background-repeat: no-repeat;
+    background-image: url('https://platform-site.yanolja.com/icons/checkbox-unselected.svg?inline');
+  }
+
+  input[type='checkbox']:checked + label {
+    background-image: url('https://platform-site.yanolja.com/icons/checkbox-selected.svg?inline');
+  }
+
+  input[type='radio'] {
+    width: 24px;
+    height: 24px;
+    cursor: pointer;
+    position: relative;
+    top: 4px;
+    line-height: 30px;
+  }
+  
+  input[type='radio'] + label {
+    height: 30px;
+    line-height: 30px;
+    cursor: pointer;
+    padding-left: 10px;
+  }
+
+  button {
+    width: 100%;
+    height: 45px;
+    background-color: #de2e5f;
+    color: #fff;
+    font-size: 16px;
+    font-weight: 700;
+    margin-bottom: 20px;
+    cursor: pointer;
+  }
+  
+  button:disabled {
+    width: 100%;
+    height: 45px;
+    background-color: #919191;
+    color: #fff;
+    font-size: 16px;
+    font-weight: 700;
+    margin-bottom: 20px;
+    cursor: not-allowed;
+  }
+
+  .agreeSection {
+    font-size: 16px;
+
+    input[type='checkbox'] + label {
+      background-image: url('https://platform-site.yanolja.com/icons/checkbox-blue-line-unselected.svg?inline');
+    }
+    input[type='checkbox']:checked + label {
+      background-image: url('https://platform-site.yanolja.com/icons/checkbox-blue-line-selected.svg?inline');
+    }
+  }
+
+  .notice {
+    background-color: #fef8f2;
+    border-radius: 4px;
+    color: #1a1a1a;
+    font-size: 14px;
+    line-height: 22px;
+    padding: 10px 10px;
+
+    h5 {
+      color: #e67000;
+      font-weight: 700;
+      line-height: 20px;
+
+      i {
+        margin-right: 5px;
+      }
+      p {
+        margin-bottom: 5px;
+      }
+    }
+  }
+`;
+
+export const FormArticle = styled.article`
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #eee;
+  margin: 20px 0px;
+
+  p {
+    font-size: 14px;
+  }
+`;
+
+export const SectionTitle = styled.h3`
+  color: #1a1a1a;
+  font-size: 20px;
+  padding: 15px 0px;
+  font-weight: 700;
+`;
+
+export const SectionBody = styled.div`
+  display: flex;
+  justify-content: space-around;
+  margin: 10px 0;
+  
+  div{
+    width: 100%;
+  }
+`;
+
+export const Guidance = styled.div`
+  background-color: #f2f2f2;
+  border-radius: 4px;
+  font-size: 14px;
+  line-height: 15.96px;
+  padding: 10px;
+  margin-bottom: 10px;
+`;
+
+export const Necessary = styled.span`
+  color: #de2e5f;
+`;
+
+export const InputDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #ffffff;
+  border-bottom-color: #4d4c4c;
+  padding: 8px 0px;
+  line-height: 21px;
+
+  input{
+    font-size: 14px;
+  }
+`;
+
+export const TotalWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin: 20px 0px;
+
+  span:second-child {
+    font-weight: 700;
+  }
+`;
+
+export const PaymentPolicy = styled.p`
+  font-size: 14px;
+  color: #919191;
+  line-height: 20px;
+  margin-bottom: 10px;
+`;

--- a/frontend/src/components/Payment/PaymentForm.tsx
+++ b/frontend/src/components/Payment/PaymentForm.tsx
@@ -1,0 +1,14 @@
+import Agreement from 'components/Payment/Agreement';
+import Notice from 'components/Payment/Notice';
+import Policy from 'components/Payment/Policy';
+import PriceInfo from 'components/Payment/PriceInfo';
+import UserInfo from 'components/Payment/UserInfo';
+import Visiting from 'components/Payment/Visiting';
+
+const PaymentForm = () => {
+  return (
+
+  )
+}
+
+export default PaymentForm;

--- a/frontend/src/components/Payment/Policy.tsx
+++ b/frontend/src/components/Payment/Policy.tsx
@@ -1,0 +1,12 @@
+import { PaymentPolicy } from "./Payment.style";
+
+const Policy = () => {
+  return (
+    <PaymentPolicy>
+      (주)더놀자는 통신판매중개업자로서, 통신판매의 당사자가 아니라는 사실을 고지하며 상품의 결제, 이용 및 환불
+      등과 관련한 의무와 책임은 각 판매자에게 있습니다.
+    </PaymentPolicy>
+  )
+}
+
+export default Policy;

--- a/frontend/src/components/Payment/PriceInfo.tsx
+++ b/frontend/src/components/Payment/PriceInfo.tsx
@@ -7,11 +7,11 @@ const PriceInfo = ({ cost }) => {
       <section>
         <TotalWrapper>
           <span>총 예약 금액</span>
-          <span style={{ fontWeight: 700 }}>{cost}원</span>
+          <span style={{ fontWeight: 700 }}>{cost.toLocaleString()}원</span>
         </TotalWrapper>
         <TotalWrapper style={{ fontWeight: 700 }}>
           <span>결제 금액</span>
-          <span style={{ color: '#de2e5f', fontSize: '18px' }}>{cost}원</span>
+          <span style={{ color: '#de2e5f', fontSize: '18px' }}>{cost.toLocaleString()}원</span>
         </TotalWrapper>
       </section>
     </FormArticle>

--- a/frontend/src/components/Payment/PriceInfo.tsx
+++ b/frontend/src/components/Payment/PriceInfo.tsx
@@ -1,0 +1,21 @@
+import { SectionTitle, FormArticle, TotalWrapper } from './Payment.style';
+
+const PriceInfo = ({ cost }) => {
+  return (
+    <FormArticle>
+      <SectionTitle>금액 및 할인 정보</SectionTitle>
+      <section>
+        <TotalWrapper>
+          <span>총 예약 금액</span>
+          <span style={{ fontWeight: 700 }}>{cost}원</span>
+        </TotalWrapper>
+        <TotalWrapper style={{ fontWeight: 700 }}>
+          <span>결제 금액</span>
+          <span style={{ color: '#de2e5f', fontSize: '18px' }}>{cost}원</span>
+        </TotalWrapper>
+      </section>
+    </FormArticle>
+  )
+}
+
+export default PriceInfo;

--- a/frontend/src/components/Payment/UserInfo.tsx
+++ b/frontend/src/components/Payment/UserInfo.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { FormArticle, Guidance, InputDiv, Necessary, SectionTitle } from "./Payment.style";
+
+const UserInfo = ({ reservation, setReservation, phone }) => {
+  const [sameUser, setSameUser] = useState(false);
+
+  const handleClick = () => {
+    setReservation({
+      ...reservation,
+      phone: !sameUser ? phone : ''
+    })
+
+    setSameUser(!sameUser)
+  }
+
+  const handleInput = e => {
+    setReservation({
+      ...reservation,
+      [e.target.id]: e.target.value
+    })
+  }
+
+  return (
+    <FormArticle>
+      <SectionTitle>
+        이용자 정보<Necessary>*</Necessary>
+      </SectionTitle>
+      <Guidance>상품 이용 시 필요한 필수 정보입니다.</Guidance>
+      <section>
+        <input type="checkbox" id="sameUser" onClick={handleClick} />
+        <label htmlFor="sameUser">예약자 정보와 동일합니다.</label>
+      </section>
+      <section>
+        <label htmlFor="username">
+          성명<Necessary>*</Necessary>
+        </label>
+        <InputDiv>
+          <input type="text" id="username" value={reservation.username || ''} onInput={handleInput} placeholder="성명을 입력해주세요" />
+        </InputDiv>
+      </section>
+      <section>
+        <label htmlFor="phone">
+          휴대폰 번호<Necessary>*</Necessary>
+        </label>
+        <InputDiv>
+          <input type="tel" id="phone" value={reservation.phone || ''} onInput={handleInput} placeholder="휴대폰 번호를 입력해주세요" />
+        </InputDiv>
+      </section>
+    </FormArticle>
+  )
+}
+
+export default UserInfo;

--- a/frontend/src/components/Payment/Visiting.tsx
+++ b/frontend/src/components/Payment/Visiting.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from "react";
+import { FormArticle, Necessary, SectionBody, SectionTitle } from "./Payment.style";
+
+
+const Visiting = ({ reservation, setReservation }) => {
+
+  const carRef = useRef();
+
+  // 숙소 방문 수단을 기본적으로 차량으로 세팅
+  useEffect(() => {
+    carRef.current.checked = reservation.hasCar;
+  }, []);
+
+  const handleVisited = () => {
+    setReservation({
+      ...reservation,
+      hasCar: carRef.current.checked
+    })
+  }
+
+  return (
+    <FormArticle>
+      <SectionTitle>
+        숙소 방문 수단<Necessary>*</Necessary>
+      </SectionTitle>
+      <SectionBody>
+        <div className="visited">
+          <input type="radio" ref={carRef} name="visited" id="car" onChange={handleVisited} />
+          <label htmlFor="car">차량</label>
+        </div>
+        <div className="visited">
+          <input type="radio" name="visited" id="work" onChange={handleVisited} />
+          <label htmlFor="work">도보</label>
+        </div>
+      </SectionBody>
+    </FormArticle>
+  )
+}
+
+export default Visiting;

--- a/frontend/src/pages/Detail/Rooms.tsx
+++ b/frontend/src/pages/Detail/Rooms.tsx
@@ -10,6 +10,7 @@ import Spinner from 'components/Spinner/Spinner';
 import { getReservedRooms } from 'src/utils/reservations';
 
 const Rooms = () => {
+
   const { id }=useParams();
   const location=useLocation();
   const queryData = QueryString.parse(location.search, { ignoreQueryPrefix: true });
@@ -28,6 +29,12 @@ const Rooms = () => {
     if(queryData.checkOut) setEndDate(new Date(queryData.checkOut));
   },[]);
 
+  const SELECTED_ROOM="SELECTED_ROOM";
+
+  useEffect(()=>{
+    window.sessionStorage.setItem(SELECTED_ROOM, JSON.stringify({...selectedRoom, startDate, endDate}));
+  },[selectedRoom]);
+
   useEffect(() => {
     const requestRooms = async () => {
       setIsLoaded(true);
@@ -36,7 +43,7 @@ const Rooms = () => {
       
       const Rooms = await getAllRoomList(hotelId, checkIn, checkOut);
       const reservedRooms = await getReservedRooms(hotelId, checkIn, checkOut);
-      console.log(reservedRooms)
+      
       const nonReservedRooms=reservedRooms.length?Rooms.filter(room=>reservedRooms.indexOf(room.name) === -1) : Rooms;
       setRooms(nonReservedRooms);
       setIsLoaded(false);

--- a/frontend/src/pages/Reservation/Reservation.tsx
+++ b/frontend/src/pages/Reservation/Reservation.tsx
@@ -5,9 +5,10 @@ import PriceInfo from 'components/Payment/PriceInfo';
 import UserInfo from 'components/Payment/UserInfo';
 import Visiting from 'components/Payment/Visiting';
 import { useEffect, useRef, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { selectAuth } from 'src/contexts/auth';
 import { useAppSelector } from 'src/contexts/state.type';
+import changeDateFormatToIsoSTring from 'src/utils/dateToISOString';
 import { postHotel } from 'src/utils/hotels';
 import { postPayment } from 'src/utils/payment';
 import { postReservation } from 'src/utils/reservations';
@@ -18,23 +19,21 @@ const Reservation = () => {
 
   const { id:hotelId }=useParams();
 
- // 스토리지에서 받아오기
+  const roomInfo=JSON.parse(window.sessionStorage.getItem("SELECTED_ROOM"));
+
   const selectedRoom = {
-    name: 'hotel',
-    photo:'photo url',
-    checkIn: '2020-01-01',
-    checkOut: '2020-10-10',
-    cost: 10000,
-    occupancy: 2,
-    adults: 1,
-    children: 1,
+    name: roomInfo.name,
+    photo: roomInfo.images[0].fullSizeUrl,
+    checkIn: changeDateFormatToIsoSTring(roomInfo.startDate),
+    checkOut: changeDateFormatToIsoSTring(roomInfo.endDate),
+    cost: roomInfo.ratePlans[0].price.unformattedCurrent,
+    occupancy: roomInfo.maxOccupancy.total+roomInfo.maxOccupancy.children,
+    adults: roomInfo.maxOccupancy.total,
+    children: roomInfo.maxOccupancy.children,
     spec: '[room spec]'
   };
 
-  // ================ 데이터 받아오는 형식 정해진 후 하기 ====================
-
   const { id:userId, phone } = useAppSelector(selectAuth);
-
 
   const [reservation, setReservation]=useState({
     userId : userId,
@@ -72,7 +71,6 @@ const Reservation = () => {
       await handleSubmit();
       navigate('/mypage');
     } else{
-      e.preventDefault();
       return false;
     }
   }
@@ -102,7 +100,7 @@ const Reservation = () => {
           <PriceInfo cost={selectedRoom.cost} />
           <Notice />
           <Agreement reservation={reservation} setReservation={setReservation} />
-          <button type="submit" ref={sumbmitBtn} onClick={handleClick} onSubmit={handleSubmit}>{selectedRoom.cost}원 결제하기</button>
+          <button type="submit" ref={sumbmitBtn} onClick={handleClick} onSubmit={handleSubmit}>{selectedRoom.cost.toLocaleString()}원 결제하기</button>
           <Policy />
         </fieldset>
       </form>

--- a/frontend/src/pages/Reservation/Reservation.tsx
+++ b/frontend/src/pages/Reservation/Reservation.tsx
@@ -1,18 +1,18 @@
+import Agreement from 'components/Payment/Agreement';
+import Notice from 'components/Payment/Notice';
+import Policy from 'components/Payment/Policy';
+import PriceInfo from 'components/Payment/PriceInfo';
+import UserInfo from 'components/Payment/UserInfo';
+import Visiting from 'components/Payment/Visiting';
 import { useEffect, useRef, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { selectAuth } from 'src/contexts/auth';
 import { useAppSelector } from 'src/contexts/state.type';
-import {
-  ReservationWrapper,
-  SectionTitle,
-  SectionBody,
-  Guidance,
-  FormArticle,
-  Necessary,
-  InputDiv,
-  TotalWrapper,
-  PaymentPolicy
-} from './Reservation.style';
+import { postHotel } from 'src/utils/hotels';
+import { postPayment } from 'src/utils/payment';
+import { postReservation } from 'src/utils/reservations';
+import { updateReservation } from 'src/utils/users';
+import { ReservationWrapper } from './Reservation.style';
 
 const Reservation = () => {
 
@@ -20,6 +20,8 @@ const Reservation = () => {
 
  // 스토리지에서 받아오기
   const selectedRoom = {
+    name: 'hotel',
+    photo:'photo url',
     checkIn: '2020-01-01',
     checkOut: '2020-10-10',
     cost: 10000,
@@ -31,9 +33,8 @@ const Reservation = () => {
 
   // ================ 데이터 받아오는 형식 정해진 후 하기 ====================
 
-  const { id:userId, nickname, email, phone } = useAppSelector(selectAuth);
+  const { id:userId, phone } = useAppSelector(selectAuth);
 
-  const [sameUser, setSameUser]=useState(false);
 
   const [reservation, setReservation]=useState({
     userId : userId,
@@ -51,56 +52,37 @@ const Reservation = () => {
     phone :  null,
   });
 
-  const carRef=useRef();
-  const totalAgree=useRef();
-  const agrees=useRef([]);
+  const [payment]=useState({
+    userId: userId,
+    cost: selectedRoom.cost
+  });
+
+  const [hotel]=useState({
+    name: selectedRoom.name,
+    photo: selectedRoom.photo
+  })
+
   const sumbmitBtn=useRef();
+  const navigate=useNavigate();
 
-  // 숙소 방문 수단을 기본적으로 차량으로 세팅
-  useEffect(()=>{
-    carRef.current.checked=reservation.hasCar;
-  }, []);
-
-  const handleClick=()=>{
-    setReservation({
-      ...reservation,
-        phone: !sameUser ? phone : ''
-      })
-      
-    setSameUser(!sameUser)
-  }
-
-  const handleInput = e => {
-    setReservation({
-      ...reservation,
-      [e.target.id]: e.target.value
-    })
-  }
-  
-  const handleVisited = e => {
-    setReservation({
-      ...reservation,
-      hasCar: carRef.current.checked
-    })
-  }
-
-  const handleAgree = e => {
-    if(e.target.id==='total'){
-      // 전체 동의하기에 따라 선택사항 체크박스 활성화
-      setReservation({
-        ...reservation,
-        isAgrees:e.target.checked?[true, true, true]:[false, false, false]
-      })
-      agrees.current.forEach(agree => agree.checked=e.target.checked);
+  const handleClick=async e=>{
+    e.preventDefault();
+    const isAllow=confirm(`예약자:${reservation.username} 결제 하시겠습니까?`);
+    if(isAllow){
+      await handleSubmit();
+      navigate('/mypage');
     } else{
-      const agreeArr=agrees.current.map(agree => agree.checked);
-      // 선택사항이 모두 체크되었을 때, 전체 동의하기 활성화 (!(3-true의 개수)=> 하나라도 false일 경우 false)
-      totalAgree.current.checked=Boolean(!(3-agreeArr.reduce((sum,acc)=>sum+= +acc,0)));
-      setReservation({
-        ...reservation,
-        isAgrees:agreeArr
-      })
+      e.preventDefault();
+      return false;
     }
+  }
+
+  const handleSubmit=async ()=>{
+    const reservationdata=await postReservation(reservation);
+    const reservationId=reservationdata.id;
+    await postHotel(hotel);
+    await postPayment(reservationId, payment);
+    await updateReservation(userId, reservationId);
   }
 
   useEffect(()=>{
@@ -114,108 +96,14 @@ const Reservation = () => {
       <h2 className="srOnly">예약 페이지</h2>
       <form>
         <fieldset>
-          <legend className="srOnly">이용자 정보</legend>
-          <FormArticle>
-            <SectionTitle>
-              이용자 정보<Necessary>*</Necessary>
-            </SectionTitle>
-            <Guidance>상품 이용 시 필요한 필수 정보입니다.</Guidance>
-            <section>
-              <input type="checkbox" id="sameUser" onClick={handleClick} />
-              <label htmlFor="sameUser">예약자 정보와 동일합니다.</label>
-            </section>
-            <section>
-              <label htmlFor="username">
-                성명<Necessary>*</Necessary>
-              </label>
-              <InputDiv>
-                <input type="text" id="username" value={reservation.username} onInput={handleInput} placeholder="성명을 입력해주세요" />
-              </InputDiv>
-            </section>
-            <section>
-              <label htmlFor="phone">
-                휴대폰 번호<Necessary>*</Necessary>
-              </label>
-              <InputDiv>
-                <input type="tel" id="phone" value={reservation.phone} onInput={handleInput} placeholder="휴대폰 번호를 입력해주세요" />
-              </InputDiv>
-            </section>
-          </FormArticle>
-          <FormArticle>
-            <SectionTitle>
-              숙소 방문 수단<Necessary>*</Necessary>
-            </SectionTitle>
-            <SectionBody>
-              <div className="visited">
-                <input type="radio" ref={carRef} name="visited" id="car" value="car" onChange={handleVisited} />
-                <label htmlFor="car">차량</label>
-              </div>
-              <div className="visited">
-                <input type="radio" name="visited" id="work" value="work" onChange={handleVisited} />
-                <label htmlFor="work">도보</label>
-              </div>
-            </SectionBody>
-          </FormArticle>
-          <FormArticle>
-            <SectionTitle>금액 및 할인 정보</SectionTitle>
-            <section>
-              <TotalWrapper>
-                <span>총 예약 금액</span>
-                <span style={{ fontWeight: 700 }}>{selectedRoom.cost}원</span>
-              </TotalWrapper>
-              <TotalWrapper style={{ fontWeight: 700 }}>
-                <span>결제 금액</span>
-                <span style={{ color: '#de2e5f', fontSize: '18px' }}>{selectedRoom.cost}원</span>
-              </TotalWrapper>
-            </section>
-          </FormArticle>
-          <FormArticle>
-            <SectionTitle className="srOnly">notice</SectionTitle>
-            <div className="notice">
-              <h5>
-                <i>ⓘ</i>현장결제
-              </h5>
-              <p>추가 인원 비용 등의 현장 결제 발생 상품을 확인하세요.</p>
-              <h5>
-                <i>ⓘ</i>취소 불가 및 수수료
-              </h5>
-              <p>추가 및 환불 규정에 따라 취소 불가, 수수료가 발생할 수 있습니다.</p>
-              <h5>
-                <i>ⓘ</i>미성년자 및 법정 대리인 필수
-              </h5>
-              <p>미성년자는 법정 대리인 동행 없이 투숙이 불가능합니다.</p>
-            </div>
-          </FormArticle>
-
-          <FormArticle>
-            <section>
-              <div>
-                <input type="checkbox" id="total" ref={totalAgree} onChange={handleAgree} />
-                <label htmlFor="total">전체 동의하기</label>
-              </div>
-              <div className="agreeSection">
-                <input type="checkbox" id="agree1" ref={agree=>agrees.current[0]=agree} onChange={handleAgree} />
-                <label htmlFor="agree1"> [필수] 만 14세 이상 이용 동의</label>
-              </div>
-              <div className="agreeSection">
-                <input type="checkbox" id="agree2" ref={agree=>agrees.current[1]=agree} onChange={handleAgree} />
-                <label htmlFor="agree2"> [선택] 이벤트, 혜택 정보 수신 동의</label>
-              </div>
-              <div className="agreeSection">
-                <input type="checkbox" id="agree3" ref={agree=>agrees.current[2]=agree} onChange={handleAgree} />
-                <label htmlFor="agree3"> [선택] 이벤트, 혜택 정보 전송을 위한 개인정보 수집 및 이용 동의</label>
-              </div>
-            </section>
-            <p>
-              이용규칙, 취소 및 환불 규칙, 개인정보 수집 및 이용 및 개인정보 제3자 제공에 동의하실 경우 결제하기를
-              클릭해주세요.
-            </p>
-          </FormArticle>
-          <button type="submit" ref={sumbmitBtn} disabled>{selectedRoom.cost}원 결제하기</button>
-          <PaymentPolicy>
-            (주)더놀자는 통신판매중개업자로서, 통신판매의 당사자가 아니라는 사실을 고지하며 상품의 결제, 이용 및 환불
-            등과 관련한 의무와 책임은 각 판매자에게 있습니다.
-          </PaymentPolicy>
+          <legend className="srOnly">결제 정보</legend>
+          <UserInfo reservation={reservation} setReservation={setReservation} phone={phone} />
+          <Visiting reservation={reservation} setReservation={setReservation} />
+          <PriceInfo cost={selectedRoom.cost} />
+          <Notice />
+          <Agreement reservation={reservation} setReservation={setReservation} />
+          <button type="submit" ref={sumbmitBtn} onClick={handleClick} onSubmit={handleSubmit}>{selectedRoom.cost}원 결제하기</button>
+          <Policy />
         </fieldset>
       </form>
     </ReservationWrapper>

--- a/frontend/src/utils/hotels.ts
+++ b/frontend/src/utils/hotels.ts
@@ -1,0 +1,9 @@
+import axios from "axios";
+
+const postHotel = async (hotel)=>{
+  return await axios.post('/api/reservation/hotel', hotel)
+  .then(({data})=>data)
+  .catch(e=>console.error(e));
+}
+
+export {postHotel};

--- a/frontend/src/utils/payment.ts
+++ b/frontend/src/utils/payment.ts
@@ -1,0 +1,15 @@
+import axios from "axios";
+import changeDateFormatToIsoSTring from "./dateToISOString";
+
+const postPayment = async (reservationId, payment)=>{
+  const date=new Date();
+  return await axios.post('/api/reservation/payment', {
+    reservationId:reservationId,
+    payment:payment,
+    paymentDate: changeDateFormatToIsoSTring(date)
+  })
+  .then(({data})=>data)
+  .catch(e=>console.error(e));
+}
+
+export {postPayment};

--- a/frontend/src/utils/reservations.ts
+++ b/frontend/src/utils/reservations.ts
@@ -16,4 +16,10 @@ const getReservedRooms = async (hotelId:string, checkIn:string, checkOut:string)
   .catch(e=>console.error(e));
 }
 
-export { getReservationByDate, getReservedRooms };
+const postReservation = async (reservation)=>{
+  return await axios.post('/api/reservation/reservation', reservation)
+  .then(({data})=>data)
+  .catch(e=>console.error(e));
+}
+
+export { getReservationByDate, getReservedRooms, postReservation};

--- a/frontend/src/utils/users.ts
+++ b/frontend/src/utils/users.ts
@@ -28,4 +28,12 @@ const updateUser = async (id: string, nickname: string, phone: string) => {
     .catch(e => console.log(e));
 };
 
-export { createUser, updateUser };
+const updateReservation =async (userId:string, reservationId) => {
+  return await axios.patch(`/api/reservation/user`,{
+    userId:userId,
+    reservationId:reservationId
+  }).then(({data})=>data)
+  .catch(e=>console.error(e));
+}
+
+export { createUser, updateUser, updateReservation };


### PR DESCRIPTION
Issue Number : #38 #150 #161 #166 

1. 구현한 결제페이지를 큰 컴포넌트 단위로 분리
2. 각 api 요청 작성하기
   - post: reservations, payment, hotels
   - patch: users
3. 서버에서 api 요청에 대한 처리 코드 작성
   - post: reservations, payment, hotels
   - patch: users
4. 세션 스토리지로 데이터 보관
   - Rooms.tsx 에서 선택된 객실 정보를 저장
   - Reservation.tsx 에서 선택된 객실 정보를 가져옴
5. 결제 버튼 클릭 시, 모달창 오픈
   - 다시 한번, 예약 내역을 확인할 수 있도록 설정
6. 결제 완료 후, 페이지 이동
   - 결제가 완료되면 예약자의 마이페이지로 이동