### PR TITLE
결제 페이지 변경 사항

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -135,17 +135,17 @@ app.get('/reserved/:hotelId', (req, res) => {
 app.post('/reservation/payment', (req, res) => {
   const id = generateId(payments);
   const { reservationId, payment, paymentDate } = req.body;
-  const data = { paymentId: id, reservationId: reservationId, paymentDate: paymentDate, ...payment };
+  const data = { id: id, reservationId: reservationId, paymentDate: paymentDate, ...payment };
   payments = [...payments, data];
-  console.log('payment', data);
+  // console.log('payment', data);
   res.send(data);
 })
 
 app.post('/reservation/reservation', (req, res) => {
   const id = generateId(reservations);
-  const data = { id: id, ...req.body };
+  const data = { id: id, ...req.body.reservation, hotelId: req.body.hotelId };
   reservations = [...reservations, data];
-  console.log('reservation', data);
+  // console.log('reservation', reservations);
   res.send(data);
 })
 
@@ -153,7 +153,7 @@ app.post('/reservation/hotel', (req, res) => {
   const id = generateId(hotels);
   const data = { id: id, ...req.body };
   hotels = [...hotels, data];
-  console.log('hotel', data);
+  // console.log('hotel', data);
   res.send(data);
 })
 
@@ -164,7 +164,7 @@ app.patch('/reservation/user', (req, res) => {
       return user;
     }
   })
-  console.log(users);
+  // console.log(users);
   res.send(users);
 })
 

--- a/frontend/src/components/Payment/PaymentForm.tsx
+++ b/frontend/src/components/Payment/PaymentForm.tsx
@@ -5,9 +5,21 @@ import PriceInfo from 'components/Payment/PriceInfo';
 import UserInfo from 'components/Payment/UserInfo';
 import Visiting from 'components/Payment/Visiting';
 
-const PaymentForm = () => {
-  return (
+const PaymentForm = ({ sumbmitBtn, handleClick, handleSubmit, reservation, setReservation, phone, cost }) => {
 
+  return (
+    <form>
+      <fieldset>
+        <legend className="srOnly">결제 정보</legend>
+        <UserInfo reservation={reservation} setReservation={setReservation} phone={phone} />
+        <Visiting reservation={reservation} setReservation={setReservation} />
+        <PriceInfo cost={cost} />
+        <Notice />
+        <Agreement reservation={reservation} setReservation={setReservation} />
+        <button type="submit" ref={sumbmitBtn} onClick={handleClick} onSubmit={handleSubmit}>{cost.toLocaleString()}원 결제하기</button>
+        <Policy />
+      </fieldset>
+    </form>
   )
 }
 

--- a/frontend/src/components/detail/HotelDescription.tsx
+++ b/frontend/src/components/detail/HotelDescription.tsx
@@ -11,6 +11,7 @@ import {
 } from './HotelDescription.style';
 
 const HotelDescription = ({ hotelInfo }) => {
+  window.sessionStorage.setItem("HOTEL_NAME", hotelInfo.name);
   return (
     <>
       <Description>

--- a/frontend/src/utils/reservations.ts
+++ b/frontend/src/utils/reservations.ts
@@ -16,8 +16,8 @@ const getReservedRooms = async (hotelId:string, checkIn:string, checkOut:string)
   .catch(e=>console.error(e));
 }
 
-const postReservation = async (reservation)=>{
-  return await axios.post('/api/reservation/reservation', reservation)
+const postReservation = async (reservation, hotelId)=>{
+  return await axios.post('/api/reservation/reservation', {reservation:reservation, hotelId:hotelId})
   .then(({data})=>data)
   .catch(e=>console.error(e));
 }


### PR DESCRIPTION
Issue Number: #166 #171

1. paymentId를 id로 변경
   - 동일한 함수 사용으로 통일화를 위해 이름만 변경해주었습니다
   - mockdata에서도 변경되었습니다
2. hotelIntro에서 호텔 이름 받아오기
   - 요청하는 api를 수정하거나, 한 번 더 요청하는 대신, 기존에 받아오는 부분에서 호텔 이름을 받아주었습니다
   - 결제 페이지와 동일한 방법으로 session storage를 사용했습니다
3. hotelId를 hotel json의 id로 변경
   - 호텔 고유의 id가 아닌 hotel json의 id로 변경하여 추가해주었습니다
4. 컴포넌트 분리하기


server.js의 주석을 해제하면 결제가 완료되었을 때, vscode 터미널에서 데이터를 확인할 수 있습니다