### PR TITLE
결제페이지 추가사항 및 리팩토링

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,8 @@
     "react-trigger-change": "^1.0.2",
     "redux-persist": "^6.0.0",
     "slick-carousel": "^1.8.1",
-    "styled-reset": "^4.3.4"
+    "styled-reset": "^4.3.4",
+    "sweetalert": "^2.1.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^13.2.1",

--- a/frontend/src/components/Payment/Notice.tsx
+++ b/frontend/src/components/Payment/Notice.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { SectionTitle, FormArticle } from './Payment.style';
 
 const Notice = () => {
@@ -22,4 +23,4 @@ const Notice = () => {
   )
 }
 
-export default Notice;
+export default memo(Notice);

--- a/frontend/src/components/Payment/Payment.style.ts
+++ b/frontend/src/components/Payment/Payment.style.ts
@@ -168,3 +168,49 @@ export const PaymentPolicy = styled.p`
   line-height: 20px;
   margin-bottom: 10px;
 `;
+
+export const SelectedWrapper = styled.div`
+  margin: 0 5%;
+`;
+
+export const SelectedInfo = styled.div`
+  p{
+    font-size: 16px;
+    line-height: 24px;
+    margin-top: 3px;
+  }
+  .hotelName{
+    font-weight: 700;
+    margin-bottom: 5px;
+  }
+`;
+
+export const Wrapper = styled.div`
+  margin:0 auto;
+`;
+
+export const SelectedBody = styled.div`
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+
+  article:first-child{
+    width: 100%;
+    margin-right: 30px;
+    height: 100%;
+  }
+
+  article:last-child{
+    max-width: 400px;
+    width: 35%;
+    min-width: 250px;
+    height: 335px;
+
+    img{
+      width: 260px;
+    }
+  }
+`;

--- a/frontend/src/components/Payment/PaymentForm.tsx
+++ b/frontend/src/components/Payment/PaymentForm.tsx
@@ -4,14 +4,19 @@ import Policy from 'components/Payment/Policy';
 import PriceInfo from 'components/Payment/PriceInfo';
 import UserInfo from 'components/Payment/UserInfo';
 import Visiting from 'components/Payment/Visiting';
+import { SelectedBody } from './Payment.style';
+import SelectedRoom from './SelectedRoom';
 
-const PaymentForm = ({ sumbmitBtn, handleClick, handleSubmit, reservation, setReservation, phone, cost }) => {
+const PaymentForm = ({ selectedRoom, sumbmitBtn, handleClick, handleSubmit, reservation, setReservation, phone, cost }) => {
 
   return (
     <form>
       <fieldset>
         <legend className="srOnly">결제 정보</legend>
-        <UserInfo reservation={reservation} setReservation={setReservation} phone={phone} />
+        <SelectedBody>
+          <UserInfo reservation={reservation} setReservation={setReservation} phone={phone} />
+          <SelectedRoom selectedRoom={selectedRoom} />
+        </SelectedBody>
         <Visiting reservation={reservation} setReservation={setReservation} />
         <PriceInfo cost={cost} />
         <Notice />

--- a/frontend/src/components/Payment/Policy.tsx
+++ b/frontend/src/components/Payment/Policy.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { PaymentPolicy } from "./Payment.style";
 
 const Policy = () => {
@@ -9,4 +10,4 @@ const Policy = () => {
   )
 }
 
-export default Policy;
+export default memo(Policy);

--- a/frontend/src/components/Payment/PriceInfo.tsx
+++ b/frontend/src/components/Payment/PriceInfo.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { SectionTitle, FormArticle, TotalWrapper } from './Payment.style';
 
 const PriceInfo = ({ cost }) => {
@@ -18,4 +19,4 @@ const PriceInfo = ({ cost }) => {
   )
 }
 
-export default PriceInfo;
+export default memo(PriceInfo);

--- a/frontend/src/components/Payment/SelectedRoom.tsx
+++ b/frontend/src/components/Payment/SelectedRoom.tsx
@@ -1,0 +1,23 @@
+import { memo } from "react";
+import { FormArticle, Wrapper, SectionTitle, SelectedInfo } from "./Payment.style";
+
+
+const SelectedRoom=({selectedRoom})=>{
+  return(
+    <FormArticle>
+      <Wrapper>
+        <SectionTitle>선택한 객실 정보</SectionTitle>
+        <div>
+          <img src={selectedRoom.photo} alt={selectedRoom.name} />
+        </div>
+        <SelectedInfo>
+          <p className="hotelName">{selectedRoom.hotelName}</p>
+          <p>[ {selectedRoom.name} ]</p>
+          <p>{selectedRoom.checkIn} - {selectedRoom.checkOut}</p>
+        </SelectedInfo>
+      </Wrapper>
+    </FormArticle>
+  )
+}
+
+export default memo(SelectedRoom);

--- a/frontend/src/components/Room/DetailRoomInfo.tsx
+++ b/frontend/src/components/Room/DetailRoomInfo.tsx
@@ -13,6 +13,7 @@ const DetailRoomInfo=({room, modal, toggleModal, handleClick}:ModalType)=> {
     speed: 500,
     slidesToShow: 1,
     slidesToScroll: 1,
+    lazyLoad: true,
     initialSlide: initialslider,
     nextArrow: <Button role="next" onClick={() => {}} />,
     prevArrow: <Button role="prev" onClick={() => {}} />,

--- a/frontend/src/components/Room/Room.tsx
+++ b/frontend/src/components/Room/Room.tsx
@@ -22,9 +22,9 @@ const Room = ({ room, setSelectedRoom }) => {
         <Selector />
         <Image>
           {room.images[0] ? (
-            <img src={room.images[0].fullSizeUrl}></img>
+            <img src={room.images[0].fullSizeUrl} alt={room.images[0].caption}></img>
           ) : (
-            <img src={'https://img.icons8.com/ios/344/no-image.png'} style={{ width: '30px', height: '30px' }}></img>
+            <img src={'https://img.icons8.com/ios/344/no-image.png'} style={{ width: '30px', height: '30px' }} alt="이미지 없음" ></img>
           )}
         </Image>
         <RoomInfo name={room.name} maxOccupancy={room.maxOccupancy} price={room.ratePlans[0].price} />

--- a/frontend/src/pages/Reservation/Reservation.tsx
+++ b/frontend/src/pages/Reservation/Reservation.tsx
@@ -1,14 +1,16 @@
+import swal from 'sweetalert';
+
 import PaymentForm from 'components/Payment/PaymentForm';
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { selectAuth } from 'src/contexts/auth';
 import { useAppSelector } from 'src/contexts/state.type';
 import changeDateFormatToIsoSTring from 'src/utils/dateToISOString';
-import { postHotel } from 'src/utils/hotels';
 import { postPayment } from 'src/utils/payment';
 import { postReservation } from 'src/utils/reservations';
 import { updateReservation } from 'src/utils/users';
 import { ReservationWrapper } from './Reservation.style';
+import { postHotel } from 'src/utils/hotels';
 
 const Reservation = () => {
 
@@ -60,15 +62,26 @@ const Reservation = () => {
   const sumbmitBtn=useRef();
   const navigate=useNavigate();
 
-  const handleClick=async e=>{
+  const handleClick=e=>{
     e.preventDefault();
-    const isAllow=confirm(`예약자:${reservation.username} 결제 하시겠습니까?`);
-    if(isAllow){
-      await handleSubmit();
-      navigate('/mypage');
-    } else{
-      return false;
-    }
+
+    swal({
+      title: '예약 정보를 확인해주세요!',
+      text: `예약자: ${reservation.username}\n연락처: ${reservation.phone}`,
+      icon: 'info',
+      buttons: ['취소', '결제하기']
+    }).then((result) => {
+      if (result) {
+        swal({
+          title: '결제 확인',
+          text: '결제가 성공적으로 완료되었습니다!',
+          icon: 'success',
+        })
+        handleSubmit();
+        navigate('/mypage');
+      }
+    })
+    
   }
 
   const handleSubmit=async ()=>{
@@ -89,7 +102,7 @@ const Reservation = () => {
   return (
     <ReservationWrapper>
       <h2 className="srOnly">예약 페이지</h2>
-      <PaymentForm sumbmitBtn={sumbmitBtn} handleClick={handleClick} handleSubmit={handleSubmit} reservation={reservation} setReservation={setReservation} phone={phone} cost={selectedRoom.cost} />
+      <PaymentForm selectedRoom={selectedRoom} sumbmitBtn={sumbmitBtn} handleClick={handleClick} handleSubmit={handleSubmit} reservation={reservation} setReservation={setReservation} phone={phone} cost={selectedRoom.cost} />
     </ReservationWrapper>
   );
 };


### PR DESCRIPTION
Issue Number: #166 #170 

1. 결제 페이지 추가사항
   - 호텔 이름와 객실 정보, 체크인, 체크아웃 날짜 보여주기
   - 결제 확정 전, alert 창으로 현재 예약자와 연락처 정보를 확인
2. 리팩토링
   - img 요소에 alt 속성 추가
   - React.memo 추가