### PR TITLE
Auth Store 변경 및 사용자 정보 요청 로직 추가 

### DIFF
--- a/frontend/src/app/app.tsx
+++ b/frontend/src/app/app.tsx
@@ -25,14 +25,6 @@ const Cart = lazy(() => import('src/pages/Cart/Cart'));
 const App = () => {
   const { id, nickname, email } = useAppSelector(selectAuth) as AuthType;
 
-  const MemoizedHeader = useMemo(() => {
-    return (
-      <>
-        <Header />
-      </>
-    );
-  }, [id]);
-
   const MemoizedFooter = useMemo(() => {
     return (
       <>
@@ -52,7 +44,7 @@ const App = () => {
 
   return (
     <>
-      {MemoizedHeader}
+      <Header />
       <Main>
         <SEOMetaTag />
         <Suspense fallback={<Spinner />}>

--- a/frontend/src/components/UserInfo/Profile.tsx
+++ b/frontend/src/components/UserInfo/Profile.tsx
@@ -4,7 +4,7 @@ import { ProfileEditor } from './User.type';
 import UserInfoForm from './UserInfoForm';
 import user from '/src/assets/user.svg';
 
-const Profile = ({ isEditing, setEditingMode }: ProfileEditor) => {
+const Profile = ({ isEditingMode, setEditingMode }: ProfileEditor) => {
   const memoizedTitle = useMemo(
     () => (
       <>
@@ -17,7 +17,7 @@ const Profile = ({ isEditing, setEditingMode }: ProfileEditor) => {
   return (
     <ProfileContainer>
       {memoizedTitle}
-      <UserInfoForm isEditing={isEditing} setEditingMode={setEditingMode} />
+      <UserInfoForm isEditingMode={isEditingMode} setEditingMode={setEditingMode} />
     </ProfileContainer>
   );
 };

--- a/frontend/src/components/UserInfo/User.type.ts
+++ b/frontend/src/components/UserInfo/User.type.ts
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction } from 'react';
 
 export interface ProfileEditor {
-  isEditing: boolean;
+  isEditingMode: boolean;
   setEditingMode: Dispatch<SetStateAction<boolean>>;
 }

--- a/frontend/src/containers/Header/Header.tsx
+++ b/frontend/src/containers/Header/Header.tsx
@@ -24,7 +24,7 @@ const Header = () => {
 
   netlifyIdentity.on('login', async ({ id, email, user_metadata: { full_name: nickname } }) => {
     let authorizedUser = {};
-    let storedUser = { id: null, nickname: null, email: null, phone: null, reservation: null, myReviews: null };
+    let storedUser = { id: null, nickname: null, email: null, reservation: null, myReviews: null };
     if (sessionStorage.getItem('persist:root')) {
       const { auth } = JSON.parse(sessionStorage.getItem('persist:root'));
       storedUser = JSON.parse(auth);
@@ -36,7 +36,6 @@ const Header = () => {
       id: storedUser.id ? storedUser.id : user.id,
       nickname: storedUser.nickname ? storedUser.nickname : user.nickname,
       email: storedUser.email ? storedUser.email : user.email,
-      phone: storedUser.phone ? storedUser.phone : user.phone,
       reservations: storedUser.reservation ? storedUser.reservation : user.reservation,
       myReviews: storedUser.myReviews ? storedUser.myReviews : user.myReviews,
     };

--- a/frontend/src/contexts/auth.ts
+++ b/frontend/src/contexts/auth.ts
@@ -6,7 +6,6 @@ export interface AuthType {
   id: string | null;
   nickname: string | null;
   email: string | null;
-  phone: string | null;
   reservations: number[] | null;
   myReviews: number[] | null;
 }
@@ -15,7 +14,6 @@ const initialState: AuthType = {
   id: null,
   nickname: null,
   email: null,
-  phone: null,
   reservations: null,
   myReviews: null,
 };
@@ -35,10 +33,6 @@ export const auth = createSlice({
     },
   },
 });
-
-// export interface RootState {
-//   auth: AuthType;
-// }
 
 export const { authLogIn, authLogOut, authUpdate } = auth.actions;
 export const selectAuth = (state: RootState) => state.auth;

--- a/frontend/src/pages/MyPage/MyPage.tsx
+++ b/frontend/src/pages/MyPage/MyPage.tsx
@@ -6,16 +6,16 @@ import SignOut from './MyPage.style';
 import Profile from 'components/UserInfo/Profile';
 
 const MyPage = () => {
-  const [isEditing, setEditingMode] = useState<boolean>(false);
+  const [isEditingMode, setEditingMode] = useState<boolean>(false);
 
   return (
     <>
       <Helmet>
         <title>{setDocumentTitle('마이페이지')}</title>
       </Helmet>
-      <Profile isEditing={isEditing} setEditingMode={setEditingMode} />
+      <Profile isEditingMode={isEditingMode} setEditingMode={setEditingMode} />
       <ReservationList />
-      <SignOut>{isEditing ? <button className="submit">회원탈퇴</button> : ''}</SignOut>,
+      <SignOut>{isEditingMode ? <button className="submit">회원탈퇴</button> : ''}</SignOut>,
     </>
   );
 };

--- a/frontend/src/utils/users.ts
+++ b/frontend/src/utils/users.ts
@@ -1,5 +1,8 @@
 import axios from 'axios';
 
+const isValidProfile = (nickname: string, password: string) =>
+  /^[ㄱ-힣a-zA-Z0-9._]{2,6}$/.test(nickname) && /^[0-9]{11}$/.test(password);
+
 const createUser = async ({ id, email, nickname }) => {
   return await axios
     .post(`/api/users`, {
@@ -28,26 +31,32 @@ const updateUser = async (id: string, nickname: string, phone: string) => {
     .catch(e => console.log(e));
 };
 
-const updateReservation =async (userId:string, reservationId) => {
-  return await axios.patch(`/api/reservation/user`,{
-    userId:userId,
-    reservationId:reservationId
-  }).then(({data})=>data)
-  .catch(e=>console.error(e));
-}
+const updateReservation = async (userId: string, reservationId) => {
+  return await axios
+    .patch(`/api/reservation/user`, {
+      userId: userId,
+      reservationId: reservationId,
+    })
+    .then(({ data }) => data)
+    .catch(e => console.error(e));
+};
 
-const updateReview =async (id:string, nickname:string) => {
-  return await axios.patch(`/api/review/user`,{
-    id:id,
-    nickname:nickname
-  }).then(({data})=>data)
-  .catch(e=>console.error(e));
-}
+const updateReview = async (id: string, nickname: string) => {
+  return await axios
+    .patch(`/api/review/user`, {
+      id: id,
+      nickname: nickname,
+    })
+    .then(({ data }) => data)
+    .catch(e => console.error(e));
+};
 
-const getPhoneNumber = async (id:string) => {
-  return await axios.post('/api/user/phone', {
-    id:id
-  }).then(({data})=>data)
-  .catch(e=>console.error(e));
-}
-export { createUser, updateUser, updateReservation, updateReview, getPhoneNumber };
+const getPhoneNumber = async (id: string) => {
+  return await axios
+    .post('/api/user/phone', {
+      id: id,
+    })
+    .then(({ data }) => data)
+    .catch(e => console.error(e));
+};
+export { isValidProfile, createUser, updateUser, updateReservation, updateReview, getPhoneNumber };


### PR DESCRIPTION
#222 

1. 이슈에 기재했듯 Auth 리듀서가 Redux-Persist를 이용하기 때문에 클라이언트의 세션 스토리지에서 사용자의 민감한 정보(연락처)를 바로 확인할 수 있다는 보안적 이슈가 있었습니다.
특정 리듀서만 Persist에서 관리하도록 설정할 수 있으므로 민감 데이터를 Auth에서 분리하는 방법도 있지만, 별도로 관리해야 할 데이터가 많지 않은 상황이라 크게 효율적이지 않다고 판단했습니다. 
따라서 연락처의 경우에만 서버에 한번 더 요청하도록 변경하였습니다. 

2. 연락처 변경 이후 새로고침시 반영되지 않는 이슈가 있습니다. 이는 Redux-persist에서 연락처를 분리하여 발생하는 문제입니다. 새로고침시 JSON 파일에서 데이터를 읽어오는데,  **JSON 파일을 업데이트하는 코드는 구현하지 않았기 때문**입니다. 이 부분을 구현한다면 실제 DB처럼 정상적으로 동작하겠지만 저희의 기획 범위는 아니니까요. 현상에 대해 이해하는 것만으로 충분할 것 같습니다. 
 
더 좋은 방법이 있다면 언제든 공유해 주세요.  😄
